### PR TITLE
ADD: estructura de etiquetas para el home

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @StexRoles @SID
+* @StexRoles @GrupoSemanadeingenioSID

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,42 @@
+import { lilita } from "./layout";
 
 export default function Home() {
   return (
-    <main className="">
-      
-    </main>
+    <div>
+        <header></header> {/* ESPACIO PARA EL COMPONENTE HEADER */}
+
+        <main>
+          {/* SECCION PARA EL BANNER */}
+          <section>
+
+          </section>
+
+          {/* SECCION PARA EL CONTENIDO */}
+          <section>
+            {/* ARTICULO PARA LAS ACTIVIDADES */}
+            <article>
+
+            </article>
+
+            {/* ARTICULO PARA LOS CURSOS */}
+            <article>
+
+            </article>
+
+            {/* ARTICULO PARA LOS PROYECTOS */}
+            <article>
+
+            </article>
+
+            {/* ARTICULO PARA LOS EQUIPOS*/}
+            <article>
+
+            </article>
+          </section>
+
+        </main>
+
+        <footer></footer> {/* ESPACIO PARA EL COMPONENTE FOOTER */}
+    </div>
   );
 }


### PR DESCRIPTION
Cree la estructura de etiquetas en la pagina principal para empezar a dividir los elementos del proyecto